### PR TITLE
💚 set specific titles for public and private view

### DIFF
--- a/src/views/List.vue
+++ b/src/views/List.vue
@@ -342,6 +342,8 @@ export default {
     this.resetListInput()
     // finished loading
     this.loading = false
+    // set browser title
+    document.title = this.admin ? 'wishlist - admin: ' + this.list.title : 'wishlist - ' + this.list.title
   },
   methods: {
     // retrieve list object


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change improves the browser tab/window title for public and private views.

## Benefits

Tabs/Windows now always contain the wishlist title. It's now possible to separate between multiple different wishlists and between the public and private view.

## Applicable Issues

Closes #3 
