### PR TITLE
Fix alert toasting

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,5 +24,5 @@ export const notify = (
   });
 
   document.body.append(alert);
-  return alert.toast();
+  return alert?.toast();
 };


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

For some reason, the `toast()` function is called on a non-existent alert element.

![image](https://github.com/user-attachments/assets/a7650595-e9ce-4769-8502-64b2fc674aa3)

This PR softens the function call.
